### PR TITLE
Change path to stl meshes to gazebo-compatible

### DIFF
--- a/launch/spawn_gazebo_entity.launch.py
+++ b/launch/spawn_gazebo_entity.launch.py
@@ -111,7 +111,8 @@ def generate_launch_description():
             "-x", pose_x,
             "-y", pose_y,
             "-z", "0.2",
-            "-Y", pose_yaw
+            "-Y", pose_yaw,
+            "-package_to_model"
         ],
         output="screen",
     )


### PR DESCRIPTION
## Purpose
Gazebo requires path to meshes inside URDF to be in different format (`model://path_to_model`) than it requires in ROS (`package://package_name/path_to_model`). I add a flag to the spawn script to fix that.